### PR TITLE
add jarsigner plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,18 @@
           </environments>
         </configuration>
       </plugin>
+      <plugin>
+        <artifactId>maven-jarsigner-plugin</artifactId>
+        <version>1.4</version>
+        <executions>
+          <execution>
+            <id>sign</id>
+            <goals>
+              <goal>sign</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
@traiansf please review

This diff assumes that all the configuration needed to specify what certificate is used to sign the jar is specified in settings.xml. You will probably want to create a self-signed certificate on your machine in order to build locally.