### PR TITLE
Continuous compiliation/execution.

### DIFF
--- a/com.runtimeverification.match/src/com/runtimeverification/match/RVMatchCitation.java
+++ b/com.runtimeverification.match/src/com/runtimeverification/match/RVMatchCitation.java
@@ -1,6 +1,5 @@
 package com.runtimeverification.match;
 
-import org.eclipse.debug.core.ILaunch;
 import org.eclipse.linuxtools.valgrind.core.AbstractValgrindMessage;
 import org.eclipse.linuxtools.valgrind.core.IValgrindMessage;
 
@@ -10,8 +9,8 @@ public class RVMatchCitation extends AbstractValgrindMessage {
 	private String details;
 	private String url;
 
-	public RVMatchCitation(IValgrindMessage parent, String text, ILaunch launch, String source, String section, String details, String url) {
-		super(parent, text, launch);
+	public RVMatchCitation(IValgrindMessage parent, String text, String source, String section, String details, String url) {
+		super(parent, text);
 		this.source = source;
 		this.section = section;
 		this.details = details;

--- a/com.runtimeverification.match/src/com/runtimeverification/match/RVMatchPlugin.java
+++ b/com.runtimeverification.match/src/com/runtimeverification/match/RVMatchPlugin.java
@@ -22,6 +22,12 @@ import org.eclipse.core.runtime.IExtensionPoint;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
+import org.eclipse.debug.core.DebugPlugin;
+import org.eclipse.debug.core.ILaunch;
+import org.eclipse.debug.core.ILaunchManager;
+import org.eclipse.debug.core.model.ISourceLocator;
+import org.eclipse.debug.ui.DebugUITools;
+import org.eclipse.debug.ui.sourcelookup.ISourceLookupResult;
 import org.eclipse.linuxtools.valgrind.ui.IValgrindToolView;
 import org.eclipse.linuxtools.valgrind.ui.ValgrindViewPart;
 import org.eclipse.swt.widgets.Display;
@@ -344,4 +350,20 @@ public class RVMatchPlugin extends AbstractUIPlugin {
         log(status, msg, null);
     }
 
+	public ISourceLocator getSourceLocator(String file) {
+		ILaunchManager manager = DebugPlugin.getDefault().getLaunchManager();
+		for (ILaunch launch : manager.getLaunches()) {
+			ISourceLocator locator = launch.getSourceLocator();
+			if (locator != null) {
+				ISourceLookupResult result = DebugUITools.lookupSource(file, locator);
+				Object sourceElement = result.getSourceElement();
+
+				if (sourceElement != null) {
+					return locator;
+				}
+			}
+		}
+		return null;
+	}
+   
 }

--- a/com.runtimeverification.match/src/org/eclipse/linuxtools/valgrind/core/AbstractValgrindMessage.java
+++ b/com.runtimeverification.match/src/org/eclipse/linuxtools/valgrind/core/AbstractValgrindMessage.java
@@ -21,7 +21,6 @@ import org.eclipse.linuxtools.valgrind.core.IValgrindMessage;
 public class AbstractValgrindMessage implements IValgrindMessage {
 
     private IValgrindMessage parent;
-    private ILaunch launch;
     private ArrayList<IValgrindMessage> children;
     private String text;
 
@@ -31,11 +30,10 @@ public class AbstractValgrindMessage implements IValgrindMessage {
      * @param text - message text, cannot be null
      * @param launch - launch object, can be null
      */
-    public AbstractValgrindMessage(IValgrindMessage parent, String text, ILaunch launch) {
+    public AbstractValgrindMessage(IValgrindMessage parent, String text) {
         children = new ArrayList<>();
         this.parent = parent;
         this.text = text;
-        this.launch = launch;
 
         if (parent != null) {
             parent.addChild(this);
@@ -49,7 +47,7 @@ public class AbstractValgrindMessage implements IValgrindMessage {
 
     @Override
     public ILaunch getLaunch() {
-        return launch;
+        return null;
     }
 
     @Override

--- a/com.runtimeverification.match/src/org/eclipse/linuxtools/valgrind/core/ValgrindCoreParser.java
+++ b/com.runtimeverification.match/src/org/eclipse/linuxtools/valgrind/core/ValgrindCoreParser.java
@@ -45,8 +45,6 @@ public class ValgrindCoreParser {
     private static final String SEE = "see"; //$NON-NLS-1$
 
     private List<IValgrindMessage> messages;
-    private ILaunch launch;
-    private ISourceLocator locator;
 
     /**
      * When using this method make sure locator passed to this method can
@@ -59,8 +57,8 @@ public class ValgrindCoreParser {
      *            - launch object, can be null
      * @throws IOException if file is not found or error reading it
      */
-    public ValgrindCoreParser(File inputFile, ILaunch launch) throws IOException {
-    	this(launch);
+    public ValgrindCoreParser(File inputFile) throws IOException {
+    	this();
 
         BufferedReader br = new BufferedReader(new FileReader(inputFile));
         messages = parseBuffer(br);
@@ -138,10 +136,10 @@ public class ValgrindCoreParser {
             String filename = (String) parsed[0];
             int lineNo = (Integer) parsed[1];
             int columnNo = (Integer) parsed[2];
-            return new ValgrindStackFrame(message, line, launch, locator, filename, lineNo, columnNo);
+            return new ValgrindStackFrame(message, line, filename, lineNo, columnNo);
         } else if (line.startsWith(SEE)) {
         	line = line.substring(SEE.length()).trim();
-            int urlStart = line.indexOf("http://");
+        	int urlStart = line.indexOf("http://");
         	String url;
         	if (urlStart != -1) {
         		url = line.substring(urlStart);
@@ -162,9 +160,9 @@ public class ValgrindCoreParser {
         	if (sectionName != null) {
         		line += " (" +  sectionName + ")";
         	}
-        	return new RVMatchCitation(message, line, launch, source, section, details, url);
+        	return new RVMatchCitation(message, line, source, section, details, url);
         }
-        return new ValgrindError(message, line, launch);
+        return new ValgrindError(message, line);
     }
 
     /**
@@ -180,9 +178,9 @@ public class ValgrindCoreParser {
     	messages.clear();
 	}
 
-    public ValgrindCoreParser(ILaunch launch) throws IOException {
-        this.launch = launch;
-        this.locator = copyLaunchSourceLocator(launch);
+    public ValgrindCoreParser() throws IOException {
+//        this.launch = launch;
+//        this.locator = copyLaunchSourceLocator(launch);
         messages = new ArrayList<>();
 	}
     

--- a/com.runtimeverification.match/src/org/eclipse/linuxtools/valgrind/core/ValgrindError.java
+++ b/com.runtimeverification.match/src/org/eclipse/linuxtools/valgrind/core/ValgrindError.java
@@ -27,8 +27,8 @@ public class ValgrindError extends AbstractValgrindMessage {
      * @param launch - launch object can be null
      * @param pid - process pid
      */
-    public ValgrindError(IValgrindMessage parent, String text, ILaunch launch) {
-        super(parent, text, launch);
+    public ValgrindError(IValgrindMessage parent, String text) {
+        super(parent, text);
     }
 
     @Override

--- a/com.runtimeverification.match/src/org/eclipse/linuxtools/valgrind/core/ValgrindInfo.java
+++ b/com.runtimeverification.match/src/org/eclipse/linuxtools/valgrind/core/ValgrindInfo.java
@@ -27,8 +27,8 @@ public class ValgrindInfo extends AbstractValgrindMessage {
      * @param text - message test cannot be null
      * @param launch - launch object can be null
      */
-    public ValgrindInfo(IValgrindMessage parent, String text, ILaunch launch) {
-        super(parent, text, launch);
+    public ValgrindInfo(IValgrindMessage parent, String text) {
+        super(parent, text);
     }
 
 }

--- a/com.runtimeverification.match/src/org/eclipse/linuxtools/valgrind/core/ValgrindStackFrame.java
+++ b/com.runtimeverification.match/src/org/eclipse/linuxtools/valgrind/core/ValgrindStackFrame.java
@@ -13,8 +13,12 @@ package org.eclipse.linuxtools.valgrind.core;
 
 import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.model.ISourceLocator;
+import org.eclipse.debug.ui.DebugUITools;
+import org.eclipse.debug.ui.sourcelookup.ISourceLookupResult;
 import org.eclipse.linuxtools.valgrind.core.AbstractValgrindMessage;
 import org.eclipse.linuxtools.valgrind.core.IValgrindMessage;
+
+import com.runtimeverification.match.RVMatchPlugin;
 
 /**
  * Valgrind stack frame message, i.e. message that carry a location of the error or a single stack frame info
@@ -23,7 +27,6 @@ public class ValgrindStackFrame extends AbstractValgrindMessage {
 	protected String file;
 	protected int line;
 	protected int column;
-	private ISourceLocator locator;
 
     /**
      * Constructor
@@ -34,12 +37,11 @@ public class ValgrindStackFrame extends AbstractValgrindMessage {
      * @param file - string representation of a source file (path)
      * @param line - line number of the source
      */
-	public ValgrindStackFrame(IValgrindMessage parent, String text, ILaunch launch, ISourceLocator locator, String file, int line, int column) {
-		super(parent, text, launch);
+	public ValgrindStackFrame(IValgrindMessage parent, String text, String file, int line, int column) {
+		super(parent, text);
 		this.file = file;
 		this.line = line;
 		this.column = column;
-		this.locator = locator;
 	}
 
 	/**
@@ -75,8 +77,10 @@ public class ValgrindStackFrame extends AbstractValgrindMessage {
 	 * @return source locator object, can be null
 	 */
 	public ISourceLocator getSourceLocator() {
-		if (locator != null)
+		ISourceLocator locator = RVMatchPlugin.getDefault().getSourceLocator(file);
+		if (locator != null) {
 			return locator;
+		}
 		if (getLaunch() != null) {
 			return getLaunch().getSourceLocator();
 		}


### PR DESCRIPTION
Switched from the by-launch model to the continuous one, to allow capturing and reporting of output for both compilation and execution.

Must find a better mechanism to clean-up the error panes as currently the compilation errors, although generated, are removed by our post-build listener.

do not review yet.