### PR TITLE
remove showView from polling loop to prevent continuous grabbing of f…

### DIFF
--- a/com.runtimeverification.match/src/com/runtimeverification/match/ReportExecutionOutput.java
+++ b/com.runtimeverification.match/src/com/runtimeverification/match/ReportExecutionOutput.java
@@ -148,7 +148,7 @@ public class ReportExecutionOutput {
 		RVMatchPlugin.getDefault().refreshView();
 
 		// show view
-		RVMatchPlugin.getDefault().showView();
+		// RVMatchPlugin.getDefault().showView();
 	}
 
 	private String formatRecord(List<String> record) {


### PR DESCRIPTION
…ocus

When we get a whole lot of errors all at once, the old code was continuously grabbing focus in a way that made it impossible to use Eclipse effectively. I tested it with this line commented out and it seems to work fine and the errors pane still appears when you launch the application, so I think we're good.